### PR TITLE
Remove last names with apostophes

### DIFF
--- a/lib/ffaker/data/name/last_names
+++ b/lib/ffaker/data/name/last_names
@@ -79,7 +79,6 @@ Cruickshank
 Cummerata
 Cummings
 Dach
-D'Amore
 Daniel
 Dare
 Daugherty
@@ -305,16 +304,10 @@ Nikolaus
 Nitzsche
 Nolan
 Oberbrunner
-O'Connell
-O'Conner
-O'Hara
-O'Keefe
-O'Kon
 Oga
 Okuneva
 Olson
 Ondricka
-O'Reilly
 Orn
 Ortiz
 Osinski


### PR DESCRIPTION
Despite having `html_safe_last_name` we were still getting sporadic test fails because `street_address` (and some other methods) can contain `last_name`s, ex:
```
    def street_name
      case rand(2)
      when 0 then "#{Name.last_name} #{street_suffix}"
      when 1 then "#{Name.first_name} #{street_suffix}"
      end
    end
```

Rather than change every place that uses `last_name` or make a corresponding `html_safe_...` method, it's easiest to just take the problem names out.